### PR TITLE
fix: crashing if format is null

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # printf
 
 - A simple `printf` clone as a team project
+- Don't forget to check __betty style__ before commit
 
 ## Build
 
@@ -9,3 +10,9 @@
 ```bash
 gcc -Wall -Werror -Wextra -pedantic -std=gnu89 *.c tests/test1.c && ./a.out
 ```
+
+## Test files
+
+1. `tests/main.c`
+2. `tests/test1.c`
+3. `tests/test2.c`

--- a/printf.c
+++ b/printf.c
@@ -17,6 +17,8 @@ int _printf(const char *format, ...)
 		{ 0, (void *)0 },
 	};
 
+	if (!format)
+		return (-1);
 	va_start(ap, format);
 	for (; *format; format++)
 	{

--- a/tests/test2.c
+++ b/tests/test2.c
@@ -6,5 +6,11 @@ int main() {
     _printf("length: %d\n", r);
     r = _printf("number: %d, zero: %i, negative: %d\n", 10, 0, -50);
     _printf("length: %d\n", r);
+    r = _printf("null: %s\n", (void *)0);
+    _printf("length: %d\n", r);
+    r = _printf((void *)0);
+    _printf("length: %d\n", r);
+    r = _printf("");
+    _printf("length: %d\n", r);
     return 0;
 }


### PR DESCRIPTION
Handle the case if the `format` argument in the `_printf` function is **NULL**